### PR TITLE
Update slash command sync logic

### DIFF
--- a/src/lib/registry/slashes.ts
+++ b/src/lib/registry/slashes.ts
@@ -48,8 +48,18 @@ export class SlashRegistry extends Registry<SlashCommand> {
    * Syncs the commands to Discord
    */
   async sync() {
-    this.manager.syncCommands();
     await this.manager.syncGlobalCommands();
+
+    const guildIDs: string[] = [];
+    for (const [, command] of this.manager.commands) {
+      if (command.guildID && !guildIDs.includes(command.guildID)) guildIDs.push(command.guildID);
+    }
+
+    for (const guildID of guildIDs) {
+      try {
+        await this.manager.syncCommandsIn(guildID);
+      } catch () {}
+    }
   }
 
   /**

--- a/src/lib/registry/slashes.ts
+++ b/src/lib/registry/slashes.ts
@@ -58,7 +58,7 @@ export class SlashRegistry extends Registry<SlashCommand> {
     for (const guildID of guildIDs) {
       try {
         await this.manager.syncCommandsIn(guildID);
-      } catch () {}
+      } catch (e) {}
     }
   }
 


### PR DESCRIPTION
Looking at the `sync` function, it seems as if it is syncing global commands twice (since `SlashCreator.syncCommands` syncs both global and guild commands), so this pretty much uses the same logic thats inside that function, so you can await syncing all you want. Not sure if you want guild-specific sync errors thrown so I just catched it here.